### PR TITLE
🐛 fix: add event type to notifications and notify win/lose points

### DIFF
--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -40,11 +40,19 @@ notifRouter.get('/test', async (req: Request, res: Response) => {
 const notifyLevelUp = (userId: number, title: string) => {
   const session = sessions.get(userId)
   if (session?.notify) {
-    session.notify({ userId, title })
+    session.notify({ event: 'levelUp', userId, title })
+  }
+}
+
+const notifyWinPoints = (userId: number, points: number, loss: boolean) => {
+  const session = sessions.get(userId)
+  if (session?.notify) {
+    session.notify({ event: loss ? 'lossPoints' : 'winPoints', userId, points })
   }
 }
 
 export {
   notifyLevelUp,
+  notifyWinPoints,
 }
 export default notifRouter

--- a/src/utils/addPointsToUser.ts
+++ b/src/utils/addPointsToUser.ts
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize'
-import { notifyLevelUp } from '../routes/notifications'
+import { notifyLevelUp, notifyWinPoints } from '../routes/notifications'
 import { User, Level, PointHistory } from '../models'
 
 const addPointsToUser = async (
@@ -45,6 +45,8 @@ const addPointsToUser = async (
     fromUserId: options.fromUserId,
     type: points < 0 ? 'remove' : action,
   })
+
+  notifyWinPoints(user.id, points, points < 0)
 }
 
 export default addPointsToUser


### PR DESCRIPTION
Enhance the notification system to include explicit event types. Add functionality for notifying users about point changes, including the distinction between win and loss points.